### PR TITLE
Refactor TimeTablePage and related files.

### DIFF
--- a/assets/timetable.json
+++ b/assets/timetable.json
@@ -1,5 +1,5 @@
 {
-    "timetable": {
+ 
       "Monday": [
         {
           "subject": "Computer Science",
@@ -215,7 +215,6 @@
           "teacher": "Kuya Kim",
           "period": "Period 5"
         }
-      ]
-    }
-  }
+      ]    
+}
   

--- a/lib/interfaces/display_values.dart
+++ b/lib/interfaces/display_values.dart
@@ -1,0 +1,4 @@
+abstract class DisplayValues {
+    String get value;
+    String get displayName;
+}

--- a/lib/interfaces/string_values.dart
+++ b/lib/interfaces/string_values.dart
@@ -1,0 +1,4 @@
+abstract class StringValues {
+    String get toStringValue;
+    String get shortened;
+}

--- a/lib/interfaces/string_values.dart
+++ b/lib/interfaces/string_values.dart
@@ -1,4 +1,0 @@
-abstract class StringValues {
-    String get toStringValue;
-    String get shortened;
-}

--- a/lib/pages/common_widgets/cards/custom_item_card.dart
+++ b/lib/pages/common_widgets/cards/custom_item_card.dart
@@ -3,11 +3,11 @@ import 'package:school_erp/features/transition/clean_slide_transition.dart';
 import 'package:school_erp/theme/colors.dart';
 
 class CustomItemCard extends StatelessWidget {
-    final Widget slideRoute;
+    final Widget? slideRoute;
     final List<Widget> itemContents;
 
     const CustomItemCard(
-    {super.key, required this.slideRoute, required this.itemContents});
+    {super.key, this.slideRoute, required this.itemContents});
 
     @override
     Widget build(BuildContext context) {
@@ -16,12 +16,14 @@ class CustomItemCard extends StatelessWidget {
 
         return InkWell(
             onTap: () {
-                Navigator.push(
-                    context,
-                    createSlideRoute(
-                        slideRoute,
-                    ),
-                );
+                if (slideRoute != null) {
+                    Navigator.push(
+                        context,
+                        createSlideRoute(
+                            slideRoute!,
+                        ),
+                    );
+                }
             },
             child: Card(
                 margin: EdgeInsets.only(bottom: verticalPadding),

--- a/lib/pages/common_widgets/dividers/general_divider.dart
+++ b/lib/pages/common_widgets/dividers/general_divider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+// Pass either symetric height/width values or individual height/width values, but not both.
 class GeneralDivider extends StatelessWidget {
     final double? topDividerSpaceHeight;
     final double? bottomDividerSpaceHeight;
@@ -20,34 +21,28 @@ class GeneralDivider extends StatelessWidget {
         this.dividerThickness = 1,
     });
 
+    double _calculateSpace(double? specificValue, double? symmetricValue, double screenDimension) {
+        if (specificValue != null) {
+            return specificValue * screenDimension / 100;
+        }
+        if (symmetricValue != null) {
+            return symmetricValue * screenDimension / 100;
+        }
+        return 0;
+    }
+
     @override
     Widget build(BuildContext context) {
         double screenHeight = MediaQuery.of(context).size.height;
         double screenWidth = MediaQuery.of(context).size.width;
 
-        // Height calcualtions
-        double topSpace = topDividerSpaceHeight != null
-            ? topDividerSpaceHeight! * screenHeight / 100 
-            : (symmetricDividerSpaceHeight != null
-                ? symmetricDividerSpaceHeight! * screenHeight / 100
-                : 0);
-        double bottomSpace = bottomDividerSpaceHeight != null
-            ? bottomDividerSpaceHeight! * screenHeight / 100 
-            : (symmetricDividerSpaceHeight != null
-                ? symmetricDividerSpaceHeight! * screenHeight / 100
-                : 0);
+        // Heights
+        double topSpace = _calculateSpace(topDividerSpaceHeight, symmetricDividerSpaceHeight, screenHeight);
+        double bottomSpace = _calculateSpace(bottomDividerSpaceHeight, symmetricDividerSpaceHeight, screenHeight);
 
-        // Width calcualtions
-        double leftSpace = leftDividerSpaceWidth != null
-            ? leftDividerSpaceWidth!
-            : (symmetricDividerSpaceWidth != null
-                ? symmetricDividerSpaceWidth! * screenWidth / 100
-                : 0);
-        double rightSpace = rightDividerSpaceWidth != null
-            ? rightDividerSpaceWidth!
-            : (symmetricDividerSpaceWidth != null
-                ? symmetricDividerSpaceWidth! * screenWidth / 100
-                : 0);
+        // Widths
+        double leftSpace = _calculateSpace(leftDividerSpaceWidth, symmetricDividerSpaceWidth, screenWidth);
+        double rightSpace = _calculateSpace(rightDividerSpaceWidth, symmetricDividerSpaceWidth, screenWidth);
 
         return Padding(
             padding: EdgeInsets.only(

--- a/lib/pages/common_widgets/dividers/general_divider.dart
+++ b/lib/pages/common_widgets/dividers/general_divider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class GeneralDivider extends StatelessWidget {
+    final double? topDividerSpaceHeight;
+    final double? bottomDividerSpaceHeight;
+    final double? leftDividerSpaceWidth;
+    final double? rightDividerSpaceWidth;
+    final double? symmetricDividerSpaceHeight;
+    final double? symmetricDividerSpaceWidth;
+    final double? dividerThickness;
+
+    const GeneralDivider({
+        super.key,
+        this.topDividerSpaceHeight,
+        this.bottomDividerSpaceHeight,
+        this.leftDividerSpaceWidth,
+        this.rightDividerSpaceWidth,
+        this.symmetricDividerSpaceHeight,
+        this.symmetricDividerSpaceWidth,
+        this.dividerThickness = 1,
+    });
+
+    @override
+    Widget build(BuildContext context) {
+        double screenHeight = MediaQuery.of(context).size.height;
+        double screenWidth = MediaQuery.of(context).size.width;
+
+        // Height calcualtions
+        double topSpace = topDividerSpaceHeight != null
+            ? topDividerSpaceHeight! * screenHeight / 100 
+            : (symmetricDividerSpaceHeight != null
+                ? symmetricDividerSpaceHeight! * screenHeight / 100
+                : 0);
+        double bottomSpace = bottomDividerSpaceHeight != null
+            ? bottomDividerSpaceHeight! * screenHeight / 100 
+            : (symmetricDividerSpaceHeight != null
+                ? symmetricDividerSpaceHeight! * screenHeight / 100
+                : 0);
+
+        // Width calcualtions
+        double leftSpace = leftDividerSpaceWidth != null
+            ? leftDividerSpaceWidth!
+            : (symmetricDividerSpaceWidth != null
+                ? symmetricDividerSpaceWidth! * screenWidth / 100
+                : 0);
+        double rightSpace = rightDividerSpaceWidth != null
+            ? rightDividerSpaceWidth!
+            : (symmetricDividerSpaceWidth != null
+                ? symmetricDividerSpaceWidth! * screenWidth / 100
+                : 0);
+
+        return Padding(
+            padding: EdgeInsets.only(
+                top: topSpace,
+                bottom: bottomSpace,
+                left: leftSpace,
+                right: rightSpace,
+            ),
+            child: Divider(
+                thickness: dividerThickness,
+                color: Colors.grey,
+            ),
+        );
+    }
+}

--- a/lib/pages/common_widgets/lists/custom_list_view.dart
+++ b/lib/pages/common_widgets/lists/custom_list_view.dart
@@ -12,13 +12,11 @@ class CustomListView<T> extends StatelessWidget{
 
     @override
     Widget build(BuildContext context) {
-        return Expanded(
-            child: ListView.builder(
-                itemCount: listOfData.length,
-                itemBuilder:(BuildContext context, int index) {
-                    return  itemBuilder(context, listOfData[index]);
-                },
-            )
+        return ListView.builder(
+            itemCount: listOfData.length,
+            itemBuilder:(BuildContext context, int index) {
+                return  itemBuilder(context, listOfData[index]);
+            },
         );
     }
 }

--- a/lib/pages/common_widgets/lists/custom_list_view.dart
+++ b/lib/pages/common_widgets/lists/custom_list_view.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class CustomListView<T> extends StatelessWidget{
+    final List<T> listOfData;
+    final Widget Function(BuildContext, T) itemBuilder;
+
+    const CustomListView({
+        super.key, 
+        required this.listOfData, 
+        required this.itemBuilder
+    });
+
+    @override
+    Widget build(BuildContext context) {
+        return Expanded(
+            child: ListView.builder(
+                itemCount: listOfData.length,
+                itemBuilder:(BuildContext context, int index) {
+                    return  itemBuilder(context, listOfData[index]);
+                },
+            )
+        );
+    }
+}

--- a/lib/pages/common_widgets/tab_bars/custom_tab_bar.dart
+++ b/lib/pages/common_widgets/tab_bars/custom_tab_bar.dart
@@ -2,17 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:school_erp/interfaces/display_values.dart';
 import 'package:school_erp/theme/colors.dart';
 
-class TimeTableTabBar<T extends DisplayValues> extends StatefulWidget {
+// Implment DisplayValues to the enum that is going to be used with this widget.
+class CustomTabBar<T extends DisplayValues> extends StatefulWidget {
     final TabController controller;
     final List<T> tabs;
 
-    const TimeTableTabBar({super.key, required this.controller, required this.tabs});
+    const CustomTabBar({super.key, required this.controller, required this.tabs});
 
     @override
     createState() => _TimeTableTabBarState();
 }
 
-class _TimeTableTabBarState extends State<TimeTableTabBar> {
+class _TimeTableTabBarState extends State<CustomTabBar> {
     @override
     Widget build(BuildContext context) {
         final screenWidth = MediaQuery.of(context).size.width;

--- a/lib/pages/common_widgets/tab_bars/custom_tab_bar.dart
+++ b/lib/pages/common_widgets/tab_bars/custom_tab_bar.dart
@@ -10,10 +10,10 @@ class CustomTabBar<T extends DisplayValues> extends StatefulWidget {
     const CustomTabBar({super.key, required this.controller, required this.tabs});
 
     @override
-    createState() => _TimeTableTabBarState();
+    createState() => _CustomTabBar();
 }
 
-class _TimeTableTabBarState extends State<CustomTabBar> {
+class _CustomTabBar extends State<CustomTabBar> {
     @override
     Widget build(BuildContext context) {
         final screenWidth = MediaQuery.of(context).size.width;

--- a/lib/pages/leave_application/leave_application_page.dart
+++ b/lib/pages/leave_application/leave_application_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:school_erp/pages/common_widgets/default_layout.dart';
 import 'package:school_erp/pages/leave_application/widgets/leave_application_form.dart';
-import 'package:school_erp/theme/colors.dart';
-import 'package:school_erp/pages/common_widgets/custom_app_bar.dart';
-import 'package:school_erp/pages/common_widgets/app_content.dart';
 
 class LeaveApplicationPage extends StatefulWidget {
     const LeaveApplicationPage({super.key});
@@ -15,20 +13,11 @@ class _LeaveApplicationPageState extends State<LeaveApplicationPage> {
 
     @override
     Widget build(BuildContext context) {
-        return Scaffold(
-            backgroundColor: AppColors.primaryColor,
-            body: Column(
-                children: [
-                    const CustomAppBar(
-                        title: 'Leave Application',
-                    ),
-                    AppContent(
-                        content: [
-                            LeaveApplicationForm()
-                        ],
-                    ),
-                ],
-            ),
+        return DefaultLayout(
+            title: "Leave Application", 
+            content: [
+                LeaveApplicationForm()
+            ]
         );
     }
 }

--- a/lib/pages/leave_application/widgets/leave_application_form.dart
+++ b/lib/pages/leave_application/widgets/leave_application_form.dart
@@ -56,6 +56,8 @@ class LeaveApplicationForm extends StatelessWidget{
             formKey: _formKey, 
             textFields: textFields, 
             formButtons: formButtons,
+            horizontalPadding: 10,
+            verticalPadding: 10,
         );
     }
 

--- a/lib/pages/timetable/helpers/timetable.dart
+++ b/lib/pages/timetable/helpers/timetable.dart
@@ -1,4 +1,6 @@
-enum DaysOfTheWeek {
+import 'package:school_erp/interfaces/string_values.dart';
+
+enum DaysOfTheWeek implements StringValues {
     monday,
     tuesday,
     wednesday,
@@ -6,7 +8,8 @@ enum DaysOfTheWeek {
     friday,
     saturday;
 
-    String get toStringValue {
+    @override
+      String get toStringValue {
         switch (this) {
             case DaysOfTheWeek.monday:
                 return 'Monday';
@@ -20,6 +23,24 @@ enum DaysOfTheWeek {
                 return 'Friday';
             case DaysOfTheWeek.saturday:
                 return 'Saturday';
+        }
+    }
+
+    @override
+      String get shortened {
+        switch (this) {
+            case DaysOfTheWeek.monday:
+                return 'MON';
+            case DaysOfTheWeek.tuesday:
+                return 'TUE';
+            case DaysOfTheWeek.wednesday:
+                return 'WED';
+            case DaysOfTheWeek.thursday:
+                return 'THU';
+            case DaysOfTheWeek.friday:
+                return 'FRI';
+            case DaysOfTheWeek.saturday:
+                return 'SAT';
         }
     }
 }

--- a/lib/pages/timetable/helpers/timetable.dart
+++ b/lib/pages/timetable/helpers/timetable.dart
@@ -14,6 +14,18 @@ enum DaysOfTheWeek implements DisplayValues{
     final String displayName;
 
     const DaysOfTheWeek(this.value, this.displayName);
+
+    static DaysOfTheWeek? getDayFromString(String day) {
+        // Opted for a try-catch block here instead of throwing an exception.
+        // Just to ignore the (if ever) invalid day from database.
+        try {
+            return DaysOfTheWeek.values.firstWhere(
+                (d) => d.value.toLowerCase() == day.toLowerCase(),
+            );
+        } catch (error) {
+            return null;
+        }
+    }
 }
 
 class ClassDetails {
@@ -62,7 +74,7 @@ class Timetable {
         Map<DaysOfTheWeek, List<ClassDetails>> timetableData = {};
 
         json.forEach((key, value) {
-                final day = _getDayFromString(key);
+                final day = DaysOfTheWeek.getDayFromString(key);
                 if (day != null && value is List) {
                     timetableData[day] = List<ClassDetails>.from(
                         value.map((classJson) => ClassDetails.fromJson(classJson))
@@ -73,22 +85,5 @@ class Timetable {
         return Timetable(data: timetableData);
     }
 
-    static DaysOfTheWeek? _getDayFromString(String day) {
-        switch (day.toLowerCase()) {
-            case 'monday':
-                return DaysOfTheWeek.monday;
-            case 'tuesday':
-                return DaysOfTheWeek.tuesday;
-            case 'wednesday':
-                return DaysOfTheWeek.wednesday;
-            case 'thursday':
-                return DaysOfTheWeek.thursday;
-            case 'friday':
-                return DaysOfTheWeek.friday;
-            case 'saturday':
-                return DaysOfTheWeek.saturday;
-            default:
-            return null;
-        }
-    }
+
 }

--- a/lib/pages/timetable/helpers/timetable.dart
+++ b/lib/pages/timetable/helpers/timetable.dart
@@ -1,48 +1,19 @@
-import 'package:school_erp/interfaces/string_values.dart';
+import 'package:school_erp/interfaces/display_values.dart';
 
-enum DaysOfTheWeek implements StringValues {
-    monday,
-    tuesday,
-    wednesday,
-    thursday,
-    friday,
-    saturday;
-
-    @override
-      String get toStringValue {
-        switch (this) {
-            case DaysOfTheWeek.monday:
-                return 'Monday';
-            case DaysOfTheWeek.tuesday:
-                return 'Tuesday';
-            case DaysOfTheWeek.wednesday:
-                return 'Wednesday';
-            case DaysOfTheWeek.thursday:
-                return 'Thursday';
-            case DaysOfTheWeek.friday:
-                return 'Friday';
-            case DaysOfTheWeek.saturday:
-                return 'Saturday';
-        }
-    }
+enum DaysOfTheWeek implements DisplayValues{
+    monday("Monday", "MON"),
+    tuesday("Tuesday", "TUE"),
+    wednesday("Wednesday", "WED"),
+    thursday("Thursday", "THU"),
+    friday("Friday", "FRI"),
+    saturday("Saturday", "SAT");
 
     @override
-      String get shortened {
-        switch (this) {
-            case DaysOfTheWeek.monday:
-                return 'MON';
-            case DaysOfTheWeek.tuesday:
-                return 'TUE';
-            case DaysOfTheWeek.wednesday:
-                return 'WED';
-            case DaysOfTheWeek.thursday:
-                return 'THU';
-            case DaysOfTheWeek.friday:
-                return 'FRI';
-            case DaysOfTheWeek.saturday:
-                return 'SAT';
-        }
-    }
+    final String value;
+    @override
+    final String displayName;
+
+    const DaysOfTheWeek(this.value, this.displayName);
 }
 
 class ClassDetails {

--- a/lib/pages/timetable/helpers/timetable.dart
+++ b/lib/pages/timetable/helpers/timetable.dart
@@ -1,0 +1,102 @@
+enum DaysOfTheWeek {
+    monday,
+    tuesday,
+    wednesday,
+    thursday,
+    friday,
+    saturday;
+
+    String get toStringValue {
+        switch (this) {
+            case DaysOfTheWeek.monday:
+                return 'Monday';
+            case DaysOfTheWeek.tuesday:
+                return 'Tuesday';
+            case DaysOfTheWeek.wednesday:
+                return 'Wednesday';
+            case DaysOfTheWeek.thursday:
+                return 'Thursday';
+            case DaysOfTheWeek.friday:
+                return 'Friday';
+            case DaysOfTheWeek.saturday:
+                return 'Saturday';
+        }
+    }
+}
+
+class ClassDetails {
+    final String subject;
+    final String time;
+    final String teacher;
+    final String period;
+
+    ClassDetails({
+        required this.subject,
+        required this.time,
+        required this.teacher,
+        required this.period,
+    });
+
+    // Create a proper Map (or object for the JS pips) of class details
+    //  from the json response.
+    factory ClassDetails.fromJson(Map<String, dynamic> json) {
+        return ClassDetails(
+            subject: json['subject'] ?? '',
+            time: json['time'] ?? '',
+            teacher: json['teacher'] ?? '',
+            period: json['period'] ?? '',
+        );
+    }
+}
+
+class Timetable {
+    final Map<DaysOfTheWeek, List<ClassDetails>> data;
+
+    Timetable({required this.data});
+
+    // Create a proper Map (or object for the JS pips) of days and classes 
+    // from the json response.
+
+    /* OUTPUT
+        {
+          Monday: [
+             {sub, teacher, time, etc}, 
+             ...
+          ],
+          ...
+        } 
+    */
+    factory Timetable.fromJson(Map<String, dynamic> json) {
+        Map<DaysOfTheWeek, List<ClassDetails>> timetableData = {};
+
+        json.forEach((key, value) {
+                final day = _getDayFromString(key);
+                if (day != null && value is List) {
+                    timetableData[day] = List<ClassDetails>.from(
+                        value.map((classJson) => ClassDetails.fromJson(classJson))
+                    );
+                }
+            }
+        );
+        return Timetable(data: timetableData);
+    }
+
+    static DaysOfTheWeek? _getDayFromString(String day) {
+        switch (day.toLowerCase()) {
+            case 'monday':
+                return DaysOfTheWeek.monday;
+            case 'tuesday':
+                return DaysOfTheWeek.tuesday;
+            case 'wednesday':
+                return DaysOfTheWeek.wednesday;
+            case 'thursday':
+                return DaysOfTheWeek.thursday;
+            case 'friday':
+                return DaysOfTheWeek.friday;
+            case 'saturday':
+                return DaysOfTheWeek.saturday;
+            default:
+            return null;
+        }
+    }
+}

--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:school_erp/pages/common_widgets/default_layout.dart';
 import 'package:school_erp/pages/timetable/helpers/timetable.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_list.dart';
-import 'package:school_erp/pages/timetable/widget/timetable_tabbar.dart';
+import 'package:school_erp/pages/common_widgets/tab_bars/custom_tab_bar.dart';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 
@@ -82,7 +82,7 @@ class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateM
             title: "Timetable",
             content: [ 
                 SizedBox(height: topSpacing),
-                TimeTableTabBar(
+                CustomTabBar(
                     controller: _tabController,
                     tabs: DaysOfTheWeek.values,
                 ),

--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:school_erp/pages/common_widgets/app_content.dart';
 import 'package:school_erp/pages/timetable/helpers/timetable.dart';
+import 'package:school_erp/pages/timetable/widget/timetable_list.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_tabbar.dart';
 import 'package:school_erp/theme/colors.dart';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:school_erp/pages/common_widgets/custom_app_bar.dart';
-import 'package:school_erp/pages/timetable/widget/timetable_card.dart';
 
 class TimeTablePage extends StatefulWidget {
     const TimeTablePage({super.key});
@@ -72,7 +72,7 @@ class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateM
             return const Center(child: CircularProgressIndicator());
         }
         final classes = List<ClassDetails>.from(timeTable?.data[day] ?? []);
-        return TimetableCard( classes: classes);
+        return TimeTableList( classes: classes);
     }
 
     @override

--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:school_erp/pages/common_widgets/app_content.dart';
+import 'package:school_erp/pages/timetable/helpers/timetable.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_tabbar.dart';
 import 'package:school_erp/theme/colors.dart';
 import 'dart:convert';
@@ -8,73 +9,95 @@ import 'package:school_erp/pages/common_widgets/custom_app_bar.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_card.dart';
 
 class TimeTablePage extends StatefulWidget {
-  const TimeTablePage({super.key});
+    const TimeTablePage({super.key});
 
-  @override
-  _TimeTablePageState createState() => _TimeTablePageState();
+    @override
+    createState() => _TimeTablePageState();
 }
 
 class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateMixin {
-  late TabController _tabController;
-  Map<String, dynamic>? timetableData;
+    late TabController _tabController;
+    late Timetable? timeTable;
+    bool _isLoading = true;
 
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 6, vsync: this);
-    _loadTimetable();
-  }
-
-
-  Future<void> _loadTimetable() async {
-    final String response = await rootBundle.loadString('assets/timetable.json');
-    setState(() {
-      timetableData = json.decode(response);
-    });
-  }
-
-  @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
-  }
-
-  Widget _buildTabContent(String day) {
-    if (timetableData == null) {
-      return const Center(child: CircularProgressIndicator());
+    @override
+    void initState() {
+        super.initState();
+        _tabController = TabController(length: 6, vsync: this);
+        _loadTimetable();
     }
-    final subjects = List<Map<String, dynamic>>.from(timetableData!['timetable'][day]);
-    return TimetableCard(day: day, subjects: subjects);
-  }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.primaryColor,
-      body: Column(
-        children: [
-          const CustomAppBar(title: 'Timetable'),
-          AppContent(
-            content: [
-              const SizedBox(height: 25),
-              TimeTableTabBar(controller: _tabController),
-              Expanded(
-                child: TabBarView(
-                  controller: _tabController,
-                  children: [
-                    _buildTabContent('Monday'),
-                    _buildTabContent('Tuesday'),
-                    _buildTabContent('Wednesday'),
-                    _buildTabContent('Thursday'),
-                    _buildTabContent('Friday'),
-                    _buildTabContent('Saturday'),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
+    Future<void> _loadTimetable() async {
+        try {
+            if (!mounted) return;
+
+            setState(() {
+                    _isLoading = true;
+                });
+
+            final String response = await rootBundle.loadString('assets/timetable.json');
+            if (response.isNotEmpty) {
+                setState(() {
+                        _isLoading = false;
+                        timeTable = Timetable.fromJson(json.decode(response));
+                    }
+                );
+            }
+
+            setState(() {
+                    _isLoading = false;
+                }
+            );
+
+        } 
+        // Handler errors better when real data is being retrieved
+        catch (e) {
+            if (!mounted) return;
+            setState(() {
+                    _isLoading = false;
+                }
+            );
+        }
+
+    }
+
+    @override
+    void dispose() {
+        _tabController.dispose();
+        super.dispose();
+    }
+
+    Widget _buildTabContent(DaysOfTheWeek day) {
+        if (_isLoading) {
+            return const Center(child: CircularProgressIndicator());
+        }
+        final classes = List<ClassDetails>.from(timeTable?.data[day] ?? []);
+        return TimetableCard( classes: classes);
+    }
+
+    @override
+    Widget build(BuildContext context) {
+        return Scaffold(
+            backgroundColor: AppColors.primaryColor,
+            body: Column(
+                children: [
+                    const CustomAppBar(title: 'Timetable'),
+                    AppContent(
+                        content: [
+                            const SizedBox(height: 25),
+                            TimeTableTabBar(controller: _tabController),
+                            Expanded(
+                                child: TabBarView(
+                                    controller: _tabController,
+                                    children: [
+                                        ...[for (var day in DaysOfTheWeek.values) _buildTabContent(day)]                                                                                                                
+                                    ],
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        );
+    }
 }

--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:school_erp/pages/common_widgets/app_content.dart';
+import 'package:school_erp/pages/common_widgets/default_layout.dart';
 import 'package:school_erp/pages/timetable/helpers/timetable.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_list.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_tabbar.dart';
-import 'package:school_erp/theme/colors.dart';
 import 'dart:convert';
 import 'package:flutter/services.dart';
-import 'package:school_erp/pages/common_widgets/custom_app_bar.dart';
 
 class TimeTablePage extends StatefulWidget {
     const TimeTablePage({super.key});
@@ -77,27 +75,23 @@ class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateM
 
     @override
     Widget build(BuildContext context) {
-        return Scaffold(
-            backgroundColor: AppColors.primaryColor,
-            body: Column(
-                children: [
-                    const CustomAppBar(title: 'Timetable'),
-                    AppContent(
-                        content: [
-                            const SizedBox(height: 25),
-                            TimeTableTabBar(controller: _tabController),
-                            Expanded(
-                                child: TabBarView(
-                                    controller: _tabController,
-                                    children: [
-                                        ...[for (var day in DaysOfTheWeek.values) _buildTabContent(day)]                                                                                                                
-                                    ],
-                                ),
-                            ),
+        double screenHeight = MediaQuery.of(context).size.height;
+        double topSpacing = screenHeight * 0.05;
+
+        return DefaultLayout(
+            title: "Timetable",
+            content: [ 
+                SizedBox(height: topSpacing),
+                TimeTableTabBar(controller: _tabController),
+                Expanded(
+                    child: TabBarView(
+                        controller: _tabController,
+                        children: [
+                            ...[for (var day in DaysOfTheWeek.values) _buildTabContent(day)]                                                                                                                
                         ],
                     ),
-                ],
-            ),
+                ),
+            ],
         );
     }
 }

--- a/lib/pages/timetable/timetable_page.dart
+++ b/lib/pages/timetable/timetable_page.dart
@@ -21,7 +21,7 @@ class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateM
     @override
     void initState() {
         super.initState();
-        _tabController = TabController(length: 6, vsync: this);
+        _tabController = TabController(length: DaysOfTheWeek.values.length, vsync: this);
         _loadTimetable();
     }
 
@@ -82,13 +82,14 @@ class _TimeTablePageState extends State<TimeTablePage> with TickerProviderStateM
             title: "Timetable",
             content: [ 
                 SizedBox(height: topSpacing),
-                TimeTableTabBar(controller: _tabController),
+                TimeTableTabBar(
+                    controller: _tabController,
+                    tabs: DaysOfTheWeek.values,
+                ),
                 Expanded(
                     child: TabBarView(
                         controller: _tabController,
-                        children: [
-                            ...[for (var day in DaysOfTheWeek.values) _buildTabContent(day)]                                                                                                                
-                        ],
+                        children: DaysOfTheWeek.values.map((day) {return _buildTabContent(day);}).toList(),
                     ),
                 ),
             ],

--- a/lib/pages/timetable/widget/timetable_card.dart
+++ b/lib/pages/timetable/widget/timetable_card.dart
@@ -1,71 +1,57 @@
 import 'package:flutter/material.dart';
 import 'package:school_erp/pages/common_widgets/cards/custom_item_card.dart';
 import 'package:school_erp/pages/common_widgets/dividers/general_divider.dart';
+import 'package:school_erp/pages/timetable/helpers/timetable.dart';
 import 'package:school_erp/theme/text_styles.dart';
-// import 'package:table_calendar/table_calendar.dart';
-// import 'package:school_erp/theme/colors.dart';
+
 
 class TimetableCard extends StatelessWidget {
-    final String day;
-    final List<Map<String, dynamic>> subjects;
+    final ClassDetails classDetails;
 
     const TimetableCard({
         super.key,
-        required this.day,
-        required this.subjects,
+        required this.classDetails,
     });
 
     @override
     Widget build(BuildContext context) {
-        return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-                Expanded(
-                    child: ListView.builder(
-                        itemCount: subjects.length,
-                        itemBuilder: (context, index) {
-                            final subject = subjects[index];
-                            return CustomItemCard(itemContents: [
-                                    Text(
-                                        subject['subject'] ?? '',
-                                        style: headingStyle().copyWith(
-                                            color: Colors.black,
-                                            fontSize: 24,
-                                            fontWeight: FontWeight.w700,
-                                        ),
-                                    ),
-                                    SizedBox(height: 10),
-                                    Text(
-                                        '${subject['time'] ?? ''}',
-                                        style: bodyStyle().copyWith(
-                                            fontSize: 18,
-                                            color: Colors.grey.shade700,
-                                        ),
-                                    ),
-                                    // Can only handle 
-                                    GeneralDivider(symmetricDividerSpaceHeight: 1),
-                                    Row(
-                                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                        children: [
-                                            Text(
-                                                '${subject['teacher'] ?? ''}',
-                                                style: bodyStyle().copyWith(
-                                                    fontSize: 18,
-                                                    color: Colors.grey.shade700,
-                                                ),
-                                            ),
-                                            Text(
-                                                '${subject['period'] ?? ''}',
-                                                style: bodyStyle().copyWith(
-                                                    fontSize: 18,
-                                                    fontWeight: FontWeight.w600,
-                                                ),
-                                            ),
-                                        ],
-                                    ),
-                                ],);
-                        },
+        return  CustomItemCard(itemContents: [
+                Text(
+                    classDetails.subject,
+                    style: headingStyle().copyWith(
+                        color: Colors.black,
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
                     ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                    classDetails.time,
+                    style: bodyStyle().copyWith(
+                        fontSize: 18,
+                        color: Colors.grey.shade700,
+                    ),
+                ),
+                // Check spacing implmentations sa widget mismo
+                GeneralDivider(symmetricDividerSpaceHeight: 1),
+                Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                        Text(
+                            classDetails.teacher,
+                            style: bodyStyle().copyWith(
+                                fontSize: 18,
+                                color: Colors.grey.shade700,
+                            ),
+                        ),
+                        Text(
+                            classDetails.period,
+                            style: bodyStyle().copyWith(
+                                fontSize: 18,
+                                fontWeight: FontWeight.w600,
+                            ),
+                        ),
+                    ],
                 ),
             ],
         );

--- a/lib/pages/timetable/widget/timetable_card.dart
+++ b/lib/pages/timetable/widget/timetable_card.dart
@@ -1,99 +1,73 @@
 import 'package:flutter/material.dart';
+import 'package:school_erp/pages/common_widgets/cards/custom_item_card.dart';
+import 'package:school_erp/pages/common_widgets/dividers/general_divider.dart';
 import 'package:school_erp/theme/text_styles.dart';
 // import 'package:table_calendar/table_calendar.dart';
 // import 'package:school_erp/theme/colors.dart';
 
 class TimetableCard extends StatelessWidget {
-  final String day;
-  final List<Map<String, dynamic>> subjects;
+    final String day;
+    final List<Map<String, dynamic>> subjects;
 
-  const TimetableCard({
-    Key? key,
-    required this.day,
-    required this.subjects,
-  }) : super(key: key);
+    const TimetableCard({
+        super.key,
+        required this.day,
+        required this.subjects,
+    });
 
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      color: Colors.white,
-      margin: const EdgeInsets.all(8.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ListView.builder(
-              itemCount: subjects.length,
-              itemBuilder: (context, index) {
-                final subject = subjects[index];
-                return Padding(
-                  padding: const EdgeInsets.all(12.0),
-                  child: Container(
-                    width: double.infinity, // Take the full width available
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: Colors.grey,
-                        width: 0.5,
-                      ),
-                      borderRadius: const BorderRadius.all(Radius.circular(10)),
+    @override
+    Widget build(BuildContext context) {
+        return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+                Expanded(
+                    child: ListView.builder(
+                        itemCount: subjects.length,
+                        itemBuilder: (context, index) {
+                            final subject = subjects[index];
+                            return CustomItemCard(itemContents: [
+                                    Text(
+                                        subject['subject'] ?? '',
+                                        style: headingStyle().copyWith(
+                                            color: Colors.black,
+                                            fontSize: 24,
+                                            fontWeight: FontWeight.w700,
+                                        ),
+                                    ),
+                                    SizedBox(height: 10),
+                                    Text(
+                                        '${subject['time'] ?? ''}',
+                                        style: bodyStyle().copyWith(
+                                            fontSize: 18,
+                                            color: Colors.grey.shade700,
+                                        ),
+                                    ),
+                                    // Can only handle 
+                                    GeneralDivider(symmetricDividerSpaceHeight: 1),
+                                    Row(
+                                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                        children: [
+                                            Text(
+                                                '${subject['teacher'] ?? ''}',
+                                                style: bodyStyle().copyWith(
+                                                    fontSize: 18,
+                                                    color: Colors.grey.shade700,
+                                                ),
+                                            ),
+                                            Text(
+                                                '${subject['period'] ?? ''}',
+                                                style: bodyStyle().copyWith(
+                                                    fontSize: 18,
+                                                    fontWeight: FontWeight.w600,
+                                                ),
+                                            ),
+                                        ],
+                                    ),
+                                ],);
+                        },
                     ),
-                    child: Padding(
-                      // Add padding inside the container for better spacing
-                      padding: const EdgeInsets.all(8.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start, // Align children to the start
-                        children: [
-                          Text(
-                            subject['subject'] ?? '',
-                            style: headingStyle().copyWith(
-                              color: Colors.black,
-                              fontSize: 24,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                          SizedBox(height: 10),
-                          Text(
-                            '${subject['time'] ?? ''}',
-                            style: bodyStyle().copyWith(
-                              fontSize: 18,
-                              color: Colors.grey.shade700,
-                            ),
-                          ),
-                          const SizedBox(height: 8), // Add space between the time and the divider
-                          const Divider(
-                            thickness: 1.0, // Thickness of the line
-                            color: Colors.grey, // Color of the line
-                          ),
-                          const SizedBox(height: 8), // Add space after the divider
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                '${subject['teacher'] ?? ''}',
-                                style: bodyStyle().copyWith(
-                                  fontSize: 18,
-                                  color: Colors.grey.shade700,
-                                ),
-                              ),
-                              Text(
-                                '${subject['period'] ?? ''}',
-                                style: bodyStyle().copyWith(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
+                ),
+            ],
+        );
+    }
 }

--- a/lib/pages/timetable/widget/timetable_list.dart
+++ b/lib/pages/timetable/widget/timetable_list.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:school_erp/pages/common_widgets/lists/custom_list_view.dart';
+import 'package:school_erp/pages/timetable/helpers/timetable.dart';
+import 'package:school_erp/pages/timetable/widget/timetable_card.dart';
+
+class TimeTableList<T> extends StatelessWidget {
+    final List<ClassDetails> classes;
+
+    const TimeTableList({
+        super.key, 
+        required this.classes, 
+    });
+
+    @override
+    Widget build(BuildContext context) {
+        return CustomListView(
+            listOfData: classes, 
+            itemBuilder: (context, classDetails) => TimetableCard(classDetails: classDetails),
+        );
+    }
+}

--- a/lib/pages/timetable/widget/timetable_list.dart
+++ b/lib/pages/timetable/widget/timetable_list.dart
@@ -3,7 +3,7 @@ import 'package:school_erp/pages/common_widgets/lists/custom_list_view.dart';
 import 'package:school_erp/pages/timetable/helpers/timetable.dart';
 import 'package:school_erp/pages/timetable/widget/timetable_card.dart';
 
-class TimeTableList<T> extends StatelessWidget {
+class TimeTableList extends StatelessWidget {
     final List<ClassDetails> classes;
 
     const TimeTableList({

--- a/lib/pages/timetable/widget/timetable_tabbar.dart
+++ b/lib/pages/timetable/widget/timetable_tabbar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:school_erp/interfaces/string_values.dart';
+import 'package:school_erp/interfaces/display_values.dart';
 import 'package:school_erp/theme/colors.dart';
 
-class TimeTableTabBar<T extends StringValues> extends StatefulWidget {
+class TimeTableTabBar<T extends DisplayValues> extends StatefulWidget {
     final TabController controller;
     final List<T> tabs;
 
@@ -43,7 +43,7 @@ class _TimeTableTabBarState extends State<TimeTableTabBar> {
                                 height: isSelected ? 50.0 : 40.0,
                                 alignment: Alignment.center,
                                 child: Text(
-                                    widget.tabs[index].shortened
+                                    widget.tabs[index].displayName
                                 ),
                             ),
                         );

--- a/lib/pages/timetable/widget/timetable_tabbar.dart
+++ b/lib/pages/timetable/widget/timetable_tabbar.dart
@@ -1,52 +1,54 @@
 import 'package:flutter/material.dart';
+import 'package:school_erp/interfaces/string_values.dart';
 import 'package:school_erp/theme/colors.dart';
 
-class TimeTableTabBar extends StatefulWidget {
-  final TabController controller;
+class TimeTableTabBar<T extends StringValues> extends StatefulWidget {
+    final TabController controller;
+    final List<T> tabs;
 
-  const TimeTableTabBar({Key? key, required this.controller}) : super(key: key);
+    const TimeTableTabBar({super.key, required this.controller, required this.tabs});
 
-  @override
-  _TimeTableTabBarState createState() => _TimeTableTabBarState();
+    @override
+    createState() => _TimeTableTabBarState();
 }
 
 class _TimeTableTabBarState extends State<TimeTableTabBar> {
-  @override
-  Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    @override
+    Widget build(BuildContext context) {
+        final screenWidth = MediaQuery.of(context).size.width;
 
-    final double responsiveTabWidth = screenWidth / 7;
+        final double responsiveTabWidth = screenWidth / 7;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20.0),
-      child: TabBar(
-        controller: widget.controller,
-        unselectedLabelStyle: const TextStyle(color: Colors.grey),
-        labelStyle:
-            const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-        indicatorColor: Colors.transparent,
-        labelPadding: EdgeInsets.zero,
-        indicator: BoxDecoration(
-          color: AppColors.primaryColor,
-          borderRadius: BorderRadius.circular(18.0),
-        ),
-        dividerColor: Colors.transparent,
-        indicatorSize: TabBarIndicatorSize.tab,
-        tabs: List.generate(6, (index) {
-          bool isSelected = widget.controller.index == index;
-          return Tab(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              width: isSelected ? responsiveTabWidth + 10 : responsiveTabWidth,
-              height: isSelected ? 50.0 : 40.0,
-              alignment: Alignment.center,
-              child: Text(
-                ["MON", "TUE", "WED", "THU", "FRI", "SAT"][index],
-              ),
+        return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20.0),
+            child: TabBar(
+                controller: widget.controller,
+                unselectedLabelStyle: const TextStyle(color: Colors.grey),
+                labelStyle:
+                const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                indicatorColor: Colors.transparent,
+                labelPadding: EdgeInsets.zero,
+                indicator: BoxDecoration(
+                    color: AppColors.primaryColor,
+                    borderRadius: BorderRadius.circular(18.0),
+                ),
+                dividerColor: Colors.transparent,
+                indicatorSize: TabBarIndicatorSize.tab,
+                tabs: List.generate(widget.tabs.length, (index) {
+                        bool isSelected = widget.controller.index == index;
+                        return Tab(
+                            child: AnimatedContainer(
+                                duration: const Duration(milliseconds: 300),
+                                width: isSelected ? responsiveTabWidth + 10 : responsiveTabWidth,
+                                height: isSelected ? 50.0 : 40.0,
+                                alignment: Alignment.center,
+                                child: Text(
+                                    widget.tabs[index].shortened
+                                ),
+                            ),
+                        );
+                    }),
             ),
-          );
-        }),
-      ),
-    );
-  }
+        );
+    }
 }


### PR DESCRIPTION
### 📝 Updates

#### Note worthy:
- Create divider for general use.
- Create timetable.dart.
- Create DaysOfTheWeek enum for consistent day values.
- Create ClassDetails class for consistent class details. (sub, teacher, etc..)
- Create Timetable class to encapsulate DaysOfTheWeek and ClassDetails for better typing. (Map<String, dynamic>? timetableData; -> late Timetable? timeTable;)
- Remove 'Timetable' key from timetable.json and expose the days directly.
- Refactor TimetableCard into a pure card widget and use CustomItemCard.
- Create CustomListView for more uniform general listviews.
- Create TimetableList and CustomListView.
- Configure TimeTableTabBar to be more reusable.
- Create StringValues interface with regards to new configuration of TimeTableTabBar.
- Add 'shortened' getter to DaysOfTheWeek with regards to new configuration of TimeTableTabBar.
- Remove Expanded widget in CustomListView to remove minor display exception/bug.
