### PR TITLE
enchancement: fix slow attendance related queries in sqlite/powersync, add additional queries for attendance

### DIFF
--- a/lib/models/attendance.dart
+++ b/lib/models/attendance.dart
@@ -13,6 +13,10 @@ class Attendance extends BaseModel {
   final TimeOfDay? timeIn;
   final AttendanceStatus? status;
 
+  // from relationships
+  final String? firstName;
+  final String? lastName;
+
   Attendance._({
     super.id,
     required this.studentId,
@@ -21,6 +25,8 @@ class Attendance extends BaseModel {
     this.checkedBy,
     this.timeIn,
     this.status,
+    this.firstName,
+    this.lastName,
   });
 
   factory Attendance({
@@ -31,6 +37,8 @@ class Attendance extends BaseModel {
     required String checkedBy,
     required AttendanceStatus status,
     TimeOfDay? timeIn,
+    String? firstName,
+    String? lastName,
   }) {
     return Attendance._(
       id: id,
@@ -40,6 +48,8 @@ class Attendance extends BaseModel {
       attendanceDate: attendanceDate,
       timeIn: timeIn,
       status: status,
+      firstName: firstName,
+      lastName: lastName,
     );
   }
 
@@ -74,20 +84,26 @@ class Attendance extends BaseModel {
       attendanceDate: DateTime.parse(row['attendance_date'] as String),
       timeIn: row['time_in'] != null ? parseTimeOfDay(row['time_in']) : null,
       status: AttendanceStatus.fromString(row['status']),
+      firstName: row['first_name'],
+      lastName: row['last_name'],
     );
   }
+
   Attendance copyWith({
     String? checkedBy,
     TimeOfDay? timeIn,
     AttendanceStatus? status,
   }) {
     return Attendance._(
-        id: id,
-        studentId: studentId,
-        sectionId: sectionId,
-        attendanceDate: attendanceDate,
-        checkedBy: checkedBy ?? this.checkedBy,
-        timeIn: timeIn ?? this.timeIn,
-        status: status ?? this.status);
+      id: id,
+      studentId: studentId,
+      sectionId: sectionId,
+      attendanceDate: attendanceDate,
+      checkedBy: checkedBy ?? this.checkedBy,
+      timeIn: timeIn ?? this.timeIn,
+      status: status ?? this.status,
+      firstName: firstName,
+      lastName: lastName,
+    );
   }
 }

--- a/lib/models/summaries/attendance_summary.dart
+++ b/lib/models/summaries/attendance_summary.dart
@@ -1,0 +1,28 @@
+import 'package:powersync/sqlite3_common.dart' as sqlite;
+
+class AttendanceSummary {
+  String id;
+  String firstName;
+  String lastName;
+  int presentTotal;
+  int absentTotal;
+  int lateTotal;
+
+  AttendanceSummary({
+    required this.id,
+    required this.firstName,
+    required this.lastName,
+    required this.presentTotal,
+    required this.absentTotal,
+    required this.lateTotal,
+  });
+
+  factory AttendanceSummary.fromRow(sqlite.Row row) => AttendanceSummary(
+        id: row['id'],
+        firstName: row['first_name'],
+        lastName: row['last_name'],
+        presentTotal: row['presentTotal'],
+        absentTotal: row['absentTotal'],
+        lateTotal: row['lateTotal'],
+      );
+}

--- a/lib/models/tables/attendances_table.dart
+++ b/lib/models/tables/attendances_table.dart
@@ -9,4 +9,6 @@ const attendancesTable = Table('attendances', [
   Column.text('status'),
   Column.text('created_at'),
   Column.text('updated_at')
+], indexes: [
+  Index('student_id', [IndexedColumn('student_id')])
 ]);

--- a/lib/models/tables/students_table.dart
+++ b/lib/models/tables/students_table.dart
@@ -3,4 +3,6 @@ import 'package:powersync/powersync.dart';
 const studentsTable = Table('students', [
   Column.text('user_id'),
   Column.text('student_no'),
+], indexes: [
+  Index('user_id', [IndexedColumn('user_id')])
 ]);

--- a/lib/models/tables/user_profiles_table.dart
+++ b/lib/models/tables/user_profiles_table.dart
@@ -6,4 +6,6 @@ const userProfilesTable = Table('user_profiles', [
   Column.text('last_name'),
   Column.text('birth_date'),
   Column.text('gender'),
+], indexes: [
+  Index('user_id', [IndexedColumn('user_id')])
 ]);

--- a/lib/repositories/attendance_repository.dart
+++ b/lib/repositories/attendance_repository.dart
@@ -1,5 +1,6 @@
 import 'package:intl/intl.dart';
 import 'package:school_erp/models/attendance.dart';
+import 'package:school_erp/models/summaries/attendance_summary.dart';
 import 'package:school_erp/models/tables/tables.dart';
 import 'package:school_erp/repositories/base_repository/base_repository.dart';
 import 'package:school_erp/repositories/base_repository/create_mixin.dart';
@@ -28,5 +29,31 @@ class AttendanceRepository extends BaseRepository<Attendance>
     }
 
     return results.map(Attendance.fromRow).toList(growable: false);
+  }
+
+  Future<List<Attendance>> getStudentsAttendanceBySection({
+    required String sectionId,
+  }) async {
+    var results =
+        await database.execute(studentsAttendanceBySectionSql, [sectionId]);
+
+    if (results.isEmpty) {
+      return [];
+    }
+
+    return results.map(Attendance.fromRow).toList(growable: false);
+  }
+
+  Future<List<AttendanceSummary>> getStudentsAttendanceSummaries({
+    required String sectionId,
+  }) async {
+    var results =
+        await database.execute(studentsAttendanceSummariesSql, [sectionId]);
+
+    if (results.isEmpty) {
+      return [];
+    }
+
+    return results.map(AttendanceSummary.fromRow).toList(growable: false);
   }
 }

--- a/lib/utils/sql_statements.dart
+++ b/lib/utils/sql_statements.dart
@@ -62,6 +62,31 @@ const studentsAttendanceByDateAndSectionSql = """
     AND section_id = ? 
 """;
 
+const studentsAttendanceBySectionSql = """
+  SELECT attendances.*,
+    user_profiles.first_name,
+    user_profiles.last_name
+  FROM attendances
+  LEFT JOIN sections ON sections.id = attendances.section_id 
+  LEFT JOIN students ON students.id = attendances.student_id
+  LEFT JOIN user_profiles ON user_profiles.user_id = students.user_id
+  WHERE section_id = ?
+""";
+
+const studentsAttendanceSummariesSql = """
+  SELECT 
+    attendances.student_id,
+    user_profiles.first_name,
+    user_profiles.last_name,
+    COUNT(CASE WHEN status = 'present' THEN 1 END) as present,
+    COUNT(CASE WHEN status = 'late' THEN 1 END) as late,
+    COUNT(CASE WHEN status = 'absent' THEN 1 END) as absent
+  FROM attendances
+  LEFT JOIN students ON students.id = attendances.student_id
+  LEFT JOIN user_profiles ON user_profiles.user_id = students.user_id
+  GROUP BY attendances.student_id, user_profiles.first_name, user_profiles.last_name
+""";
+
 const studentsBySectionSql = """
   SELECT 
     students.*, 

--- a/lib/utils/sql_statements.dart
+++ b/lib/utils/sql_statements.dart
@@ -74,17 +74,23 @@ const studentsAttendanceBySectionSql = """
 """;
 
 const studentsAttendanceSummariesSql = """
+  WITH summary AS (
   SELECT 
     attendances.student_id,
-    user_profiles.first_name,
-    user_profiles.last_name,
     COUNT(CASE WHEN status = 'present' THEN 1 END) as present,
     COUNT(CASE WHEN status = 'late' THEN 1 END) as late,
     COUNT(CASE WHEN status = 'absent' THEN 1 END) as absent
   FROM attendances
-  LEFT JOIN students ON students.id = attendances.student_id
+  WHERE attendances.attendance_date >= "2023-07-03" AND attendance_date <= "2023-07-31"
+  GROUP BY attendances.student_id
+  )
+  
+  SELECT summary.*,
+    user_profiles.first_name,
+    user_profiles.last_name
+  FROM summary
+  LEFT JOIN students ON students.id = summary.student_id
   LEFT JOIN user_profiles ON user_profiles.user_id = students.user_id
-  GROUP BY attendances.student_id, user_profiles.first_name, user_profiles.last_name
 """;
 
 const studentsBySectionSql = """

--- a/lib/utils/sql_statements.dart
+++ b/lib/utils/sql_statements.dart
@@ -81,7 +81,6 @@ const studentsAttendanceSummariesSql = """
     COUNT(CASE WHEN status = 'late' THEN 1 END) as late,
     COUNT(CASE WHEN status = 'absent' THEN 1 END) as absent
   FROM attendances
-  WHERE attendances.attendance_date >= "2023-07-03" AND attendance_date <= "2023-07-31"
   GROUP BY attendances.student_id
   )
   

--- a/lib/utils/sql_statements.dart
+++ b/lib/utils/sql_statements.dart
@@ -69,27 +69,22 @@ const studentsAttendanceBySectionSql = """
   FROM attendances
   LEFT JOIN sections ON sections.id = attendances.section_id 
   LEFT JOIN students ON students.id = attendances.student_id
-  LEFT JOIN user_profiles ON user_profiles.user_id = students.user_id
-  WHERE section_id = ?
+  LEFT JOIN user_profiles WHERE user_profiles.user_id = students.user_id
+    AND attendances.section_id = ?
 """;
 
 const studentsAttendanceSummariesSql = """
-  WITH summary AS (
   SELECT 
     attendances.student_id,
+    user_profiles.first_name,
+    user_profiles.last_name,
     COUNT(CASE WHEN status = 'present' THEN 1 END) as present,
     COUNT(CASE WHEN status = 'late' THEN 1 END) as late,
     COUNT(CASE WHEN status = 'absent' THEN 1 END) as absent
   FROM attendances
-  GROUP BY attendances.student_id
-  )
-  
-  SELECT summary.*,
-    user_profiles.first_name,
-    user_profiles.last_name
-  FROM summary
-  LEFT JOIN students ON students.id = summary.student_id
-  LEFT JOIN user_profiles ON user_profiles.user_id = students.user_id
+  LEFT JOIN students ON students.id = attendances.student_id
+  LEFT JOIN user_profiles WHERE user_profiles.user_id = students.user_id
+  GROUP BY attendances.student_id, user_profiles.first_name, user_profiles.last_name
 """;
 
 const studentsBySectionSql = """


### PR DESCRIPTION
### 🎫 Ticket

- [fix slow attendance related queries in sqlite/powersync, add additional queries for attendance](https://trello.com/c/0YlLJDfN/101-fix-slow-attendance-query-in-sqlite-powersync)

### 📦 Packages

- None

### 📝 Updates

- add index to schema for attendances, students, and user_profiles to be used in joins
- added studentsAttendanceBySection, studentsAttendanceSummaries
   (use inner join or join followed by where as opposed to left join as advised by powersync after checking explain query plan 
    output)

### 🧪 Testing Steps

- check if index is being used in the query using "EXPLAIN QUERY PLAN"
